### PR TITLE
Fix the bart model loading issue when using AutoModelForSeq2SeqLM

### DIFF
--- a/fastseq/optimizer/transformers/beam_search_optimizer.py
+++ b/fastseq/optimizer/transformers/beam_search_optimizer.py
@@ -854,4 +854,4 @@ class BartForConditionalGenerationV2(BartForConditionalGeneration):
         past = ((enc_out, new_enc_mask), reordered_past)
         return past
 
-MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[BartConfig] = BartForConditionalGeneration # pylint: disable=line-too-long
+MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING[BartConfig] = BartForConditionalGenerationV2 # pylint: disable=line-too-long


### PR DESCRIPTION
This PR will enable `AutoModelForSeq2SeqLM` to load BART model correctly and `run_eval.py` to work without issues. 