### PR TITLE
Fix the hang issue when the inference step exits unexpectedly

### DIFF
--- a/fastseq/optimizer/fairseq/generate_v2.py
+++ b/fastseq/optimizer/fairseq/generate_v2.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import logging
 import math
 import os


### PR DESCRIPTION
When the inference step exits unexpectedly, the multi-processes for post-processing will hang as no finish signal will be put into the queue. This PR fixes this case. A refactoring of fastseq-generate may be needed to better handle the failures.  