### PR TITLE
Exit with 1 instead of 0 When the inference step runs into error

### DIFF
--- a/fastseq/optimizer/fairseq/generate_v1.py
+++ b/fastseq/optimizer/fairseq/generate_v1.py
@@ -349,7 +349,12 @@ def main_v1(args):
                     generator, models, sample, prefix_tokens)
             except:
                 logging.exception(sys.exc_info()[0])
-                break
+                for p in p_list:
+                    p.terminate()
+                io_process.terminate()
+                data_queue.close()
+                message_queue.close()
+                sys.exit(1)
 
             num_generated_tokens = sum(len(h[0]['tokens']) for h in hypos)
             gen_timer.stop(num_generated_tokens)


### PR DESCRIPTION
Make fastseq-generate exit with 1 instead of 0 when the inference step breaks.
