### PR TITLE
Fix an issue in replace decorator

### DIFF
--- a/fastseq/utils/api_decorator.py
+++ b/fastseq/utils/api_decorator.py
@@ -201,7 +201,7 @@ def replace(target_obj):
     def decorator(new_obj):
         for k, v in sys.modules.items():
             if (target_obj.__name__ in v.__dict__
-                and v.__dict__[target_obj.__name__] == target_obj):
+                and v.__dict__[target_obj.__name__] is target_obj):
                 delattr(sys.modules[k], target_obj.__name__)
                 setattr(sys.modules[k], target_obj.__name__, new_obj)
                 logger.debug("In module {}, {} is replaced by {}".format(


### PR DESCRIPTION
This PR fix the below issue when running the tests on python-3.6.9. The root cause is that python does not support this kind of operation: `if (x0 == x1) ....`, when the result of (x0 == x1) is a numpy array instead of a single bool value.

```
======================================================================
ERROR: test_replace_class (utils.test_api_decorator.APIDecoratorTest)
test_replace_class (utils.test_api_decorator.APIDecoratorTest)
Test replace() decorator for class.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/datadrive/jiuchen/src/git.fastseq/tests/utils/test_api_decorator.py", line 86, in test_replace_class
    @replace(A)
  File "/datadrive/jiuchen/src/git.fastseq/fastseq/utils/api_decorator.py", line 202, in decorator
    and v.__dict__[target_obj.__name__] == target_obj):
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

