### PR TITLE
Update the speed range for T5 benchmark

### DIFF
--- a/benchmarks/models/hf_t5.sh
+++ b/benchmarks/models/hf_t5.sh
@@ -13,7 +13,7 @@ source utils.sh
 # Accuracy
 grep "t5-base wmt_en_ro/raw val " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 27.42 27.44
 # Speed on V100 16GB 250W
-grep -E "transformers_v3.0.2 t5-base wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 5 5.5
-grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7 7.5
-grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.9 8.4
+grep -E "transformers_v3.0.2 t5-base wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 4.6 5.2
+grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 6 6.5
+grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7 7.5
 


### PR DESCRIPTION
Update the speed range for T5 benchmarks based on the following result on docker with python-3.6.9:

|                Util                |  Model  |      Task     | Split | BatchSize | Samples | Tokens |  Bleu |    Rouge   | Loss | Perplexity | Runtime(seconds) | Throughput(samples/s) | Throughput(tokens/s) |
|:----------------------------------:|:-------:|:-------------:|:-----:|:---------:|:-------:|:------:|:-----:|:----------:|:----:|:----------:|:----------------:|:---------------------:|:--------------------:|
|         transformers_v3.0.2        | t5-base | wmt_en_ro/raw |  val  |     64    |   1999  |   NA   | 27.44 | NA\|NA\|NA |  NA  |     NA     |        422       |          4.7          |          NA          |
|         transformers_v3.0.2        | t5-base | wmt_en_ro/raw |  val  |     64    |   1999  |   NA   | 27.44 | NA\|NA\|NA |  NA  |     NA     |        400       |          5.0          |          NA          |
|         transformers_v3.0.2        | t5-base | wmt_en_ro/raw |  val  |     64    |   1999  |   NA   | 27.44 | NA\|NA\|NA |  NA  |     NA     |        400       |          5.0          |          NA          |
|                Util                |  Model  |      Task     | Split | BatchSize | Samples | Tokens |  Bleu |    Rouge   | Loss | Perplexity | Runtime(seconds) | Throughput(samples/s) | Throughput(tokens/s) |
| transformers_v3.0.2+fastseq_v0.0.3 | t5-base | wmt_en_ro/raw |  val  |     64    |   1999  |   NA   | 27.43 | NA\|NA\|NA |  NA  |     NA     |        318       |          6.3          |          NA          |
| transformers_v3.0.2+fastseq_v0.0.3 | t5-base | wmt_en_ro/raw |  val  |    128    |   1999  |   NA   | 27.42 | NA\|NA\|NA |  NA  |     NA     |        278       |          7.2          |          NA          |
| transformers_v3.0.2+fastseq_v0.0.3 | t5-base | wmt_en_ro/raw |  val  |     64    |   1999  |   NA   | 27.43 | NA\|NA\|NA |  NA  |     NA     |        316       |          6.3          |          NA          |
| transformers_v3.0.2+fastseq_v0.0.3 | t5-base | wmt_en_ro/raw |  val  |    128    |   1999  |   NA   | 27.42 | NA\|NA\|NA |  NA  |     NA     |        279       |          7.2          |          NA          |
| transformers_v3.0.2+fastseq_v0.0.3 | t5-base | wmt_en_ro/raw |  val  |     64    |   1999  |   NA   | 27.43 | NA\|NA\|NA |  NA  |     NA     |        312       |          6.4          |          NA          |
| transformers_v3.0.2+fastseq_v0.0.3 | t5-base | wmt_en_ro/raw |  val  |    128    |   1999  |   NA   | 27.42 | NA\|NA\|NA |  NA  |     NA     |        285       |          7.0          |          NA          |

Close #23 