### PR TITLE
Fix the error of dic changed size during iteration

### DIFF
--- a/fastseq/utils/api_decorator.py
+++ b/fastseq/utils/api_decorator.py
@@ -199,7 +199,7 @@ def replace(target_obj):
         A decorator function to replace the input object.
     """
     def decorator(new_obj):
-        for k, v in sys.modules.items():
+        for k, v in list(sys.modules.items()):
             if (target_obj.__name__ in v.__dict__
                 and v.__dict__[target_obj.__name__] is target_obj):
                 delattr(sys.modules[k], target_obj.__name__)


### PR DESCRIPTION
This PR fixes the issue reported from Song's team although we could not reproduce it at our side.

```
 import fastseq
site-packages\fastseq\__init__.py:9: in <module>
    import fastseq.optimizer  # pylint: disable=wrong-import-position
site-packages\fastseq\optimizer\__init__.py:7: in <module>
    import fastseq.optimizer.transformers
site-packages\fastseq\optimizer\transformers\__init__.py:49: in <module>
    apply_transformers_optimization()
site-packages\fastseq\optimizer\transformers\__init__.py:39: in apply_transformers_optimization
    import fastseq.optimizer.transformers.modeling_bart_optimizer_2_11_0 # pylint: disable=import-outside-toplevel
site-packages\fastseq\optimizer\transformers\modeling_bart_optimizer_2_11_0.py:54: in <module>
    class PreTrainedModelV2(PreTrainedModel):
site-packages\fastseq\utils\api_decorator.py:202: in decorator
    for k, v in sys.modules.items():
E   RuntimeError: dictionary changed size during iteration
```