### PR TITLE
Add the missing __init__.py for models module

### DIFF
--- a/fastseq/models/__init__.py
+++ b/fastseq/models/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Register models"""
+
+import fastseq.models.prophetnet_fs


### PR DESCRIPTION
This PR adds the missing __init__.py for models module, so that prophetnet model can be registered before running CLI.