### PR TITLE
Update benchmark for bart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below shows the generation speed gain by using FastSeq.
 | Model            | W/O FastSeq (in samples/s) | W/ FastSeq (in samples/s) | Speedup |
 |------------------|:--------------------------:|:-------------------------:|:-----:|
 | [ProphetNet](examples/prophetnet/README.md)       | 2.8 | 11.3  | 4.0x  |
-| [Bart (`fs`)](examples/bart/README.md)              | 2.7  | 15.0 | 5.6x  |
+| [Bart (`fs`)](examples/bart/README.md)              | 2.4  | 19.7 | 8.2x  |
 | [Bart (`hf`)](examples/bart/README.md#speedup-bart-huggingface-transformers-version-by-using-fastseq) | 3.5 | 11.4 | 3.3x  |
 | [DistilBart (`hf`)](examples/distilbart/README.md)    | 4.3  | 13.8  | 3.2x  |
 | [T5 (`hf`)](examples/t5/README.md)                  | 5.0  | 11.5  | 2.3x  |

--- a/benchmarks/models/fs_bart.sh
+++ b/benchmarks/models/fs_bart.sh
@@ -9,20 +9,25 @@
 source utils.sh
 
 # TASK - cnn dm val 1k set
-./benchmark.sh fairseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32          # each loop 7 minutes
-./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32/64/128  # each loop 5 minutes
+#./benchmark.sh fairseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32          # each loop 7 minutes
+#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32/64/128  # each loop 5 minutes
+
+#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 128  # each loop 5 minutes
+#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 & # each loop 5 minutes
+#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 64  # each loop 5 minutes
 
 ## TASK - cnn dm val full
-#./benchmark.sh fairseq bart.large.cnn cnn_dm/len-1024.bin valid 32          # each loop 2 hours
-#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm/len-1024.bin valid 32/64/128  # each loop 1.5 hours
+./benchmark.sh fairseq bart.large.cnn cnn_dm/len-1024.bin valid 32          # each loop 2 hours
+./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm/len-1024.bin valid 32/64/128/256 --max-tokens 131072 # each loop 1.5 hours
 
 # Accuracy
 grep "bart.large.cnn cnn_dm.1k/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 10.4 10.6
 # Speed on V100 16GB 250W
-grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.3 3
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 8.3 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 11.4 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.3 100
+grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.1 2.7
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.8 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.0 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 18.1 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 256 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 19.4 100
 
 ## Accuracy
 #grep "bart.large.cnn cnn_dm/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 17.9 18

--- a/benchmarks/models/fs_bart.sh
+++ b/benchmarks/models/fs_bart.sh
@@ -17,18 +17,18 @@ source utils.sh
 ./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm/len-1024.bin valid 32/64/128/256 --max-tokens 131072 # each loop 1.5 hours
 
 # Accuracy
-grep "bart.large.cnn cnn_dm.1k/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 10.4 10.6
+#grep "bart.large.cnn cnn_dm.1k/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 10.4 10.6
 # Speed on V100 16GB 250W
-grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.1 2.7
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.8 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.0 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 18.1 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 256 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 19.4 100
+#grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.3 3
+#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 8.3 100
+#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 11.4 100
+#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.3 100
 
 ## Accuracy
-#grep "bart.large.cnn cnn_dm/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 17.9 18
+grep "bart.large.cnn cnn_dm/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 17.9 18
 ## Speed on V100 16GB 250W
-#grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.2 2.4
-#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 6 100
-#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 8.7 100
-#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 10.8 100
+grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.1 2.7
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.8 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.0 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 18.1 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 256 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 19.4 100

--- a/benchmarks/models/fs_bart.sh
+++ b/benchmarks/models/fs_bart.sh
@@ -12,10 +12,6 @@ source utils.sh
 #./benchmark.sh fairseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32          # each loop 7 minutes
 #./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32/64/128  # each loop 5 minutes
 
-#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 128  # each loop 5 minutes
-#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 & # each loop 5 minutes
-#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 64  # each loop 5 minutes
-
 ## TASK - cnn dm val full
 ./benchmark.sh fairseq bart.large.cnn cnn_dm/len-1024.bin valid 32          # each loop 2 hours
 ./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm/len-1024.bin valid 32/64/128/256 --max-tokens 131072 # each loop 1.5 hours

--- a/examples/bart/README.md
+++ b/examples/bart/README.md
@@ -14,6 +14,7 @@ BART is sequence-to-sequence model trained with denoising as pretraining objecti
   |:----------------:|:-------------:|:---------------:|:--------------:|:--------------:|
   | fairseq-0.9.0    | 2.4 samples/s |       OOM       |      OOM       |      OOM       |
   | above + fastseq  | 8.1 samples/s | 13.3 samples/s  | 18.4 samples/s | 19.7 samples/s |
+\* with `--max-tokens 131072` to avoid attn_weights' total number of elements exceed INT.MAX, which is a limitation for softmax op. 
 
 ### Model
 

--- a/examples/bart/README.md
+++ b/examples/bart/README.md
@@ -10,10 +10,10 @@ BART is sequence-to-sequence model trained with denoising as pretraining objecti
 
 - CNN daily mail validation data, NVIDIA-V100-16GB
 
-  |     BatchSize    |       32      |        64       |      128       |
-  |:----------------:|:-------------:|:---------------:|:--------------:|
-  | fairseq-0.9.0    | 2.7 samples/s |       OOM       |      OOM       |
-  | above + fastseq  | 9.0 samples/s | 13.0 samples/s  | 15.0 samples/s |
+  |     BatchSize    |       32      |        64       |      128       |      256*      |
+  |:----------------:|:-------------:|:---------------:|:--------------:|:--------------:|
+  | fairseq-0.9.0    | 2.4 samples/s |       OOM       |      OOM       |      OOM       |
+  | above + fastseq  | 8.1 samples/s | 13.3 samples/s  | 18.4 samples/s | 19.7 samples/s |
 
 ### Model
 


### PR DESCRIPTION
Switch to full cnndm valid dataset. The previous subset with 1024 sample is too small, when use E2E time to measure speed.

| Dataset      | Sample Num | E2E Time     | Model Inference Time |
| :---        |    :----:   |          ---: |       ---: |
| cnndm_1024      | 1024       | 68s   | 39s  |
| cnndm_valid_set | 13367      | 724s      | 688s |