### PR TITLE
Benchmark refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Below shows the generation speed gain by using FastSeq.
 
 | Model            | W/O FastSeq (in samples/s) | W/ FastSeq (in samples/s) | Speedup |
 |------------------|:--------------------------:|:-------------------------:|:-----:|
-| [ProphetNet](examples/prophetnet/README.md)       | 3.2 | 11.3  | 3.5x  |
+| [ProphetNet](examples/prophetnet/README.md)       | 2.8 | 10.7  | 3.8x  |
 | [Bart (`fs`)](examples/bart/README.md)              | 2.4  | 19.7 | 8.2x  |
 | [Bart (`hf`)](examples/bart/README.md#speedup-bart-huggingface-transformers-version-by-using-fastseq) | 2.5 | 12.4 | 5.0x  |
-| [DistilBart (`hf`)](examples/distilbart/README.md)    | 4.3  | 18.3  | 4.3x  |
-| [T5 (`hf`)](examples/t5/README.md)                  | 5.0  | 23.4  | 4.7x  |
+| [DistilBart (`hf`)](examples/distilbart/README.md)    | 3.4  | 18.5  | 5.4x  |
+| [T5 (`hf`)](examples/t5/README.md)                  | 5.7  | 24.0  | 4.2x  |
 | [WMT16 En-De (`fs`)](examples/wmt/README.md)        | 96.0   | 417.0  | 4.3x  |
 
 - All benchmarking experiments run on NVIDIA-V100-16GB with [docker](docker/Dockerfile). Highest speed recorded for each model by tuning batch size. For parameter setting details, click link of corresponding model.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Below shows the generation speed gain by using FastSeq.
 | [Bart (`fs`)](examples/bart/README.md)              | 2.4  | 19.7 | 8.2x  |
 | [Bart (`hf`)](examples/bart/README.md#speedup-bart-huggingface-transformers-version-by-using-fastseq) | 2.5 | 12.4 | 5.0x  |
 | [DistilBart (`hf`)](examples/distilbart/README.md)    | 3.4  | 18.5  | 5.4x  |
-| [T5 (`hf`)](examples/t5/README.md)                  | 5.7  | 24.0  | 4.2x  |
+| [T5 (`hf`)](examples/t5/README.md)                  | 8.7  | 31.3  | 3.6x  |
 | [WMT16 En-De (`fs`)](examples/wmt/README.md)        | 96.0   | 417.0  | 4.3x  |
 
 - All benchmarking experiments run on NVIDIA-V100-16GB with [docker](docker/Dockerfile). Highest speed recorded for each model by tuning batch size. For parameter setting details, click link of corresponding model.

--- a/benchmarks/benchmark_fs.sh
+++ b/benchmarks/benchmark_fs.sh
@@ -56,7 +56,7 @@ mark1=" with beam="
 mark2="| Evaluated "
 for i in `seq $LOOP`; do
 for bs in "${bs_list[@]}"; do
-    echo "Processing Loop=$i/$LOOP Util=$framework_versioned Model=$model Task=$task Split=$split BS=$bs"
+    echo "`date` Processing Loop=$i/$LOOP Util=$framework_versioned Model=$model Task=$task Split=$split BS=$bs"
     start=`date +%s`
     if [[ $type == lm ]]; then
         $util $data_dir \

--- a/benchmarks/benchmark_hf.sh
+++ b/benchmarks/benchmark_hf.sh
@@ -40,7 +40,7 @@ fi
 IFS='/' read -ra bs_list <<< "$bss"
 for i in `seq $LOOP`; do
 for bs in "${bs_list[@]}"; do
-    echo "Processing Loop=$i/$LOOP Util=$framework_versioned Model=$model Task=$task Split=$split BS=$bs"
+    echo "`date` Processing Loop=$i/$LOOP Util=$framework_versioned Model=$model Task=$task Split=$split BS=$bs"
     rm -rf $SUMMARY_FILE $SCORE_FILE
     start=`date +%s`
     fastseq-generate-for-transformers $model_id $data_dir/$split.source $SUMMARY_FILE --reference_path $data_dir/$split.target --device cuda --bs $bs --fp16 --score_path $SCORE_FILE $extra_param $* > $STDOUT_FILE 2> $STDERR_FILE

--- a/benchmarks/benchmark_hf.sh
+++ b/benchmarks/benchmark_hf.sh
@@ -61,9 +61,9 @@ for bs in "${bs_list[@]}"; do
         if [ $nf -eq 4 ]; then
             bleu=`sed 's/.*"bleu": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.2f",$1}'`
         else
-            rouge1=`sed 's/.*"rouge1": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.2f",$1}'`
-            rouge2=`sed 's/.*"rouge2": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.2f",$1}'`
-            rougel=`sed 's/.*"rougeL": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.2f",$1}'`
+            rouge1=`sed 's/.*"rouge1": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.3f",$1}'`
+            rouge2=`sed 's/.*"rouge2": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.3f",$1}'`
+            rougel=`sed 's/.*"rougeL": \([.0-9]*\).*/\1/' $SCORE_FILE | awk '{printf "%.3f",$1}'`
         fi
         echo "$framework_versioned $model $task $split $bs $samples $tokens $bleu $rouge1|$rouge2|$rougel NA NA $runtime $throughput1 $throughput2" >> $perff
     else

--- a/benchmarks/benchmark_hf.sh
+++ b/benchmarks/benchmark_hf.sh
@@ -15,18 +15,19 @@ for f in "${file_list[@]}"; do
     download_if_not_in_cache https://fastseq.blob.core.windows.net/data/tasks/$task/$f $local_path
 done
 
-extra_param=""
+util=""
 if [[ $framework == transformers ]]; then
     if [[ $SKIP_BASELINE -gt 0 ]]; then
         exit 0
     fi
     ver=`pip show transformers | awk  '{if($1=="Version:")print $2}'`
     framework_versioned="transformers_v$ver"
-    extra_param="--without_fastseq_opt"
+    util="python $BASELINE_REPO/examples/seq2seq/run_eval.py"
 elif [[ "$framework" == "transformers+fastseq" ]]; then
     ver1=`pip show transformers | awk  '{if($1=="Version:")print $2}'`
     ver2=`pip show fastseq | awk  '{if($1=="Version:")print $2}'`
     framework_versioned="transformers_v$ver1+fastseq_v$ver2"
+    util="fastseq-generate-for-transformers"
 fi
 
 model_dir=$CACHE_DIR/models
@@ -43,7 +44,7 @@ for bs in "${bs_list[@]}"; do
     echo "`date` Processing Loop=$i/$LOOP Util=$framework_versioned Model=$model Task=$task Split=$split BS=$bs"
     rm -rf $SUMMARY_FILE $SCORE_FILE
     start=`date +%s`
-    fastseq-generate-for-transformers $model_id $data_dir/$split.source $SUMMARY_FILE --reference_path $data_dir/$split.target --device cuda --bs $bs --fp16 --score_path $SCORE_FILE $extra_param $* > $STDOUT_FILE 2> $STDERR_FILE
+    $util $model_id $data_dir/$split.source $SUMMARY_FILE --reference_path $data_dir/$split.target --device cuda --bs $bs --fp16 --score_path $SCORE_FILE $* > $STDOUT_FILE 2> $STDERR_FILE
     ret=$?
     end=`date +%s`
     runtime=$(($end-$start))

--- a/benchmarks/hf.sh
+++ b/benchmarks/hf.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+source utils.sh
+if [[ $SKIP_BASELINE -eq 0 ]]; then
+    export BASELINE_REPO=$CACHE_DIR/transformers_v3.0.2
+    git_clone_if_not_in_cache \
+        https://github.com/huggingface/transformers.git \
+        $BASELINE_REPO \
+        v3.0.2
+fi

--- a/benchmarks/hf.sh
+++ b/benchmarks/hf.sh
@@ -2,8 +2,9 @@
 source utils.sh
 if [[ $SKIP_BASELINE -eq 0 ]]; then
     export BASELINE_REPO=$CACHE_DIR/transformers_v3.0.2
+    #https://github.com/huggingface/transformers.git \
     git_clone_if_not_in_cache \
-        https://github.com/huggingface/transformers.git \
+	https://github.com/JiushengChen/transformers.git \
         $BASELINE_REPO \
-        v3.0.2
+        v3.0.2-ngram
 fi

--- a/benchmarks/models/fs_bart.sh
+++ b/benchmarks/models/fs_bart.sh
@@ -42,4 +42,4 @@ grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 12
 	| ./range.sh 18.1 100
 grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 256 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 19.4 100
+	| ./range.sh 19 100

--- a/benchmarks/models/fs_bart.sh
+++ b/benchmarks/models/fs_bart.sh
@@ -8,27 +8,38 @@
 #   <batch-sizes>
 source utils.sh
 
-# TASK - cnn dm val 1k set
-#./benchmark.sh fairseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32          # each loop 7 minutes
-#./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm.1k/len-1024.bin valid 32/64/128  # each loop 5 minutes
-
-## TASK - cnn dm val full
-./benchmark.sh fairseq bart.large.cnn cnn_dm/len-1024.bin valid 32          # each loop 2 hours
-./benchmark.sh fairseq+fastseq bart.large.cnn cnn_dm/len-1024.bin valid 32/64/128/256 --max-tokens 131072 # each loop 1.5 hours
+# TASK - cnn dm val full
+./benchmark.sh \
+    fairseq \
+    bart.large.cnn \
+    cnn_dm/len-1024.bin \
+    valid \
+    32
+./benchmark.sh \
+    fairseq+fastseq \
+    bart.large.cnn \
+    cnn_dm/len-1024.bin \
+    valid \
+    32/64/128/256 \
+    --max-tokens 131072
 
 # Accuracy
-#grep "bart.large.cnn cnn_dm.1k/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 10.4 10.6
+grep "bart.large.cnn cnn_dm/len-1024.bin valid " perf \
+	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
+	| ./range.sh 17.9 18
 # Speed on V100 16GB 250W
-#grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.3 3
-#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 8.3 100
-#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 11.4 100
-#grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm.1k/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.3 100
-
-## Accuracy
-grep "bart.large.cnn cnn_dm/len-1024.bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 17.9 18
-## Speed on V100 16GB 250W
-grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.1 2.7
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.8 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 13.0 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 18.1 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 256 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 19.4 100
+grep -E "fairseq_v0.9.0 bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 2.1 2.7
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 32 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 7.8 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 64 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 13.0 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 128 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 18.1 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* bart.large.cnn cnn_dm/len-1024.bin valid 256 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 19.4 100

--- a/benchmarks/models/fs_prophetnet.sh
+++ b/benchmarks/models/fs_prophetnet.sh
@@ -8,26 +8,26 @@
 #   <batch-sizes>
 source utils.sh
 
-## Download ProphetNet repo as the baseline if it does not exist
-#prophetnet_repo_path=$CACHE_DIR/ProphetNet
-#git_clone_if_not_in_cache \
-#    https://github.com/microsoft/ProphetNet.git \
-#    $prophetnet_repo_path
-#
-#./benchmark.sh \
-#    fairseq \
-#    prophetnet_large_160G_cnndm_model \
-#    cnn_dm_bert/len-512.bin \
-#    valid \
-#    64 \
-#    --user-dir $prophetnet_repo_path/src/prophetnet/
-#./benchmark.sh \
-#    fairseq+fastseq \
-#    prophetnet_large_160G_cnndm_model \
-#    cnn_dm_bert/len-512.bin \
-#    valid \
-#    64/128
-#
+# Download ProphetNet repo as the baseline if it does not exist
+prophetnet_repo_path=$CACHE_DIR/ProphetNet
+git_clone_if_not_in_cache \
+    https://github.com/microsoft/ProphetNet.git \
+    $prophetnet_repo_path
+
+./benchmark.sh \
+    fairseq \
+    prophetnet_large_160G_cnndm_model \
+    cnn_dm_bert/len-512.bin \
+    valid \
+    64 \
+    --user-dir $prophetnet_repo_path/src/prophetnet/
+./benchmark.sh \
+    fairseq+fastseq \
+    prophetnet_large_160G_cnndm_model \
+    cnn_dm_bert/len-512.bin \
+    valid \
+    64/128
+
 # Accuracy
 grep "prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid" perf \
 	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \

--- a/benchmarks/models/fs_prophetnet.sh
+++ b/benchmarks/models/fs_prophetnet.sh
@@ -8,23 +8,43 @@
 #   <batch-sizes>
 source utils.sh
 
-# Download ProphetNet repo as the baseline if it does not exist
-prophetnet_repo_path=$CACHE_DIR/ProphetNet
-git_clone_if_not_in_cache https://github.com/microsoft/ProphetNet.git $prophetnet_repo_path
-
-./benchmark.sh fairseq prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 32/64 --user-dir $prophetnet_repo_path/src/prophetnet/
-
-# ./benchmark.sh fairseq+fastseq prophetnet_large_160G_cnndm_model cnn_dm_bert/bin valid 32/64/128  # it will take 20 minutes per run
-
-./benchmark.sh fairseq+fastseq prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 32/64/128
-
+## Download ProphetNet repo as the baseline if it does not exist
+#prophetnet_repo_path=$CACHE_DIR/ProphetNet
+#git_clone_if_not_in_cache \
+#    https://github.com/microsoft/ProphetNet.git \
+#    $prophetnet_repo_path
+#
+#./benchmark.sh \
+#    fairseq \
+#    prophetnet_large_160G_cnndm_model \
+#    cnn_dm_bert/len-512.bin \
+#    valid \
+#    64 \
+#    --user-dir $prophetnet_repo_path/src/prophetnet/
+#./benchmark.sh \
+#    fairseq+fastseq \
+#    prophetnet_large_160G_cnndm_model \
+#    cnn_dm_bert/len-512.bin \
+#    valid \
+#    64/128
+#
 # Accuracy
-grep "prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid" perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 12.6 12.7
-
+grep "prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid" perf \
+	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
+	| ./range.sh 19.1 19.2
 # # Speed on V100 16GB 250W
-grep -E "fairseq_v0.9.0 prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.5 3.0
-grep -E "fairseq_v0.9.0 prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 3 3.5
-
-grep -E "fairseq_v0.9.0\+fastseq_v.* prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 5.7 6.5
-grep -E "fairseq_v0.9.0\+fastseq_v.* prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 8.5 10
-grep -E "fairseq_v0.9.0\+fastseq_v.* prophetnet_large_160G_cnndm_model cnn_dm_bert.1k/len-1024.bin valid 128 " perf | awk '{s+=$13}END{print s/NR}'| bash range.sh 10 15
+grep -E "fairseq_v0.9.0 prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid 32 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 2 3
+grep -E "fairseq_v0.9.0 prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid 64 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 2 3
+grep -E "fairseq_v0.9.0\+fastseq_v.* prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid 32 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 5.7 6.5
+grep -E "fairseq_v0.9.0\+fastseq_v.* prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid 64 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 7.5 10
+grep -E "fairseq_v0.9.0\+fastseq_v.* prophetnet_large_160G_cnndm_model cnn_dm_bert/len-512.bin valid 128 " perf \
+	| awk '{s+=$13}END{print s/NR}'\
+	| ./range.sh 10 15

--- a/benchmarks/models/fs_wmt.sh
+++ b/benchmarks/models/fs_wmt.sh
@@ -9,12 +9,33 @@
 source utils.sh
 
 # MODEL - wmt16
-./benchmark.sh fairseq wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 256
-./benchmark.sh fairseq+fastseq wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 256/512/1024 --postprocess-workers 5
+./benchmark.sh \
+    fairseq \
+    wmt16.en.de.32k \
+    wmt16_en_de_bpe32k/bin \
+    valid \
+    256
+./benchmark.sh \
+    fairseq+fastseq \
+    wmt16.en.de.32k \
+    wmt16_en_de_bpe32k/bin \
+    valid \
+    256/512/1024 \
+    --postprocess-workers 5
 # Accuracy
-grep " wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 0.05 0.07
+grep " wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid " perf \
+	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
+	| ./range.sh 0.05 0.07
 # Speed on V100 16GB 250W
-grep -E "fairseq_v0.9.0 wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 256 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 93 100
-grep -E "fairseq_v0.9.0\+fastseq_v.* wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 256 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 350 1000
-grep -E "fairseq_v0.9.0\+fastseq_v.* wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 512 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 390 1000
-grep -E "fairseq_v0.9.0\+fastseq_v.* wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 1024 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 410 1000
+grep -E "fairseq_v0.9.0 wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 256 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 93 100
+grep -E "fairseq_v0.9.0\+fastseq_v.* wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 256 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 350 1000
+grep -E "fairseq_v0.9.0\+fastseq_v.* wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 512 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 390 1000
+grep -E "fairseq_v0.9.0\+fastseq_v.* wmt16.en.de.32k wmt16_en_de_bpe32k/bin valid 1024 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 405 1000

--- a/benchmarks/models/hf_bart.sh
+++ b/benchmarks/models/hf_bart.sh
@@ -9,7 +9,7 @@
 source hf.sh
 
 # MODEL - bart large cnn from transformer
-## TASK - cnn dm val full set
+# TASK - cnn dm val full set
 ./benchmark.sh \
     transformers \
     facebook/bart-large-cnn \
@@ -29,18 +29,18 @@ source hf.sh
 grep "facebook/bart-large-cnn cnn_dm/raw val " perf \
 	| awk '{print $9}' \
 	| awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' \
-	| ./range.sh 44.78 44.82
+	| ./range.sh 0.447 0.448
 # Speed on V100 16GB 250W
 grep -E "transformers_v3.0.2 facebook/bart-large-cnn cnn_dm/raw val 32 " perf \
 	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
 	| ./range.sh 2 3
 grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 32 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 7.6 100
+	| ./range.sh 7 100
 grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 64 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 11.3 100
+	| ./range.sh 11 100
 grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 128 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 12.4 100
+	| ./range.sh 12 100
 

--- a/benchmarks/models/hf_bart.sh
+++ b/benchmarks/models/hf_bart.sh
@@ -16,14 +16,16 @@ source hf.sh
     cnn_dm/raw \
     val \
     32 \
-    --task summarization
+    --task summarization \
+    --no_repeat_ngram_size 3
 ./benchmark.sh \
     transformers+fastseq \
     facebook/bart-large-cnn \
     cnn_dm/raw \
     val \
     32/64/128 \
-    --task summarization
+    --task summarization \
+    --no_repeat_ngram_size 3
 
 # Accuracy
 grep "facebook/bart-large-cnn cnn_dm/raw val " perf \

--- a/benchmarks/models/hf_bart.sh
+++ b/benchmarks/models/hf_bart.sh
@@ -9,26 +9,38 @@
 source utils.sh
 
 # MODEL - bart large cnn from transformer
-# TASK - cnn dm val 1k set
-#./benchmark.sh transformers facebook/bart-large-cnn cnn_dm.1k/raw val 32 --task summarization    # each loop 5 minutes
-#./benchmark.sh transformers+fastseq facebook/bart-large-cnn cnn_dm.1k/raw val 32/64/128 --task summarization    # each loop 8 minutes
 ## TASK - cnn dm val full set
-./benchmark.sh transformers facebook/bart-large-cnn cnn_dm/raw val 32 --task summarization    # each loop 2 hours
-./benchmark.sh transformers+fastseq facebook/bart-large-cnn cnn_dm/raw val 32/64/128 --task summarization    # each loop 2 hours
+./benchmark.sh \
+    transformers \
+    facebook/bart-large-cnn \
+    cnn_dm/raw \
+    val \
+    32 \
+    --task summarization
+./benchmark.sh \
+    transformers+fastseq \
+    facebook/bart-large-cnn \
+    cnn_dm/raw \
+    val \
+    32/64/128 \
+    --task summarization
 
 # Accuracy
-#grep "facebook/bart-large-cnn cnn_dm.1k/raw val " perf | awk '{print $9}' | awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' | bash range.sh 34.8 35
-## Speed on V100 16GB 250W
-#grep -E "transformers_v3.0.2 facebook/bart-large-cnn cnn_dm.1k/raw val 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 3.3 3.7
-#grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.6 100
-#grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 11.3 100
-#grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 12.4 100
-
-# Accuracy
-grep "facebook/bart-large-cnn cnn_dm/raw val " perf | awk '{print $9}' | awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' | bash range.sh 44.78 44.82
+grep "facebook/bart-large-cnn cnn_dm/raw val " perf \
+	| awk '{print $9}' \
+	| awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' \
+	| ./range.sh 44.78 44.82
 # Speed on V100 16GB 250W
-grep -E "transformers_v3.0.2 facebook/bart-large-cnn cnn_dm/raw val 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.2 2.4
-grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 32 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 7.6 100
-grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 11.3 100
-grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 12.4 100
+grep -E "transformers_v3.0.2 facebook/bart-large-cnn cnn_dm/raw val 32 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 2 3
+grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 32 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 7.6 100
+grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 64 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 11.3 100
+grep -E "transformers_v3.0.2\+fastseq_v.* facebook/bart-large-cnn cnn_dm/raw val 128 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 12.4 100
 

--- a/benchmarks/models/hf_bart.sh
+++ b/benchmarks/models/hf_bart.sh
@@ -6,7 +6,7 @@
 #   <task>
 #   <split> # train/val/test (text) or train/valid/test (binary)
 #   <batch-sizes>
-source utils.sh
+source hf.sh
 
 # MODEL - bart large cnn from transformer
 ## TASK - cnn dm val full set

--- a/benchmarks/models/hf_distibart.sh
+++ b/benchmarks/models/hf_distibart.sh
@@ -6,7 +6,7 @@
 #   <task>
 #   <split> # train/val/test (text) or train/valid/test (binary)
 #   <batch-sizes>
-source utils.sh
+source hf.sh
 
 # MODEL - distibart cnn
 ## TASK - cnn dm val full set

--- a/benchmarks/models/hf_distibart.sh
+++ b/benchmarks/models/hf_distibart.sh
@@ -9,27 +9,28 @@
 source hf.sh
 
 # MODEL - distibart cnn
-## TASK - cnn dm val full set
+# TASK - cnn dm val full set
 ./benchmark.sh \
     transformers \
     hf.sshleifer.distilbart-cnn-12-6.tar.gz \
     cnn_dm/raw \
     val \
     64 \
-    --task summarization  # each loop takes 2.5 hours
+    --task summarization
 ./benchmark.sh \
     transformers+fastseq \
     hf.sshleifer.distilbart-cnn-12-6.tar.gz \
     cnn_dm/raw \
     val \
     64/128 \
-    --task summarization  # each loop takes 2.5 hours
+    --task summarization \
+    --postprocess_workers 3
 
 # Accuracy
 grep "hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val " perf \
 	| awk '{print $9}' \
 	| awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' \
-	| ./range.sh 45 45.1
+	| ./range.sh 0.45 0.452
 # Speed on V100 16GB 250W
 grep -E "transformers_v3.0.2 hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64 " perf \
 	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \

--- a/benchmarks/models/hf_distibart.sh
+++ b/benchmarks/models/hf_distibart.sh
@@ -9,25 +9,34 @@
 source utils.sh
 
 # MODEL - distibart cnn
-# TASK - cnn dm val 1k set
-#./benchmark.sh transformers hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm.1k/raw val 64 --task summarization  # each loop takes 7 minutes
-#./benchmark.sh transformers+fastseq hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm.1k/raw val 64/128 --task summarization  # each loop takes 7 minutes
 ## TASK - cnn dm val full set
-./benchmark.sh transformers hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64 --task summarization  # each loop takes 2.5 hours
-./benchmark.sh transformers+fastseq hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64/128 --task summarization  # each loop takes 2.5 hours
+./benchmark.sh \
+    transformers \
+    hf.sshleifer.distilbart-cnn-12-6.tar.gz \
+    cnn_dm/raw \
+    val \
+    64 \
+    --task summarization  # each loop takes 2.5 hours
+./benchmark.sh \
+    transformers+fastseq \
+    hf.sshleifer.distilbart-cnn-12-6.tar.gz \
+    cnn_dm/raw \
+    val \
+    64/128 \
+    --task summarization  # each loop takes 2.5 hours
 
 # Accuracy
-#grep "hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm.1k/raw val " perf | awk '{print $9}' | awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' | bash range.sh 35.1 35.3
-## Speed on V100 16GB 250W
-#grep -E "transformers_v3.0.2 hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm.1k/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 4.0 6.0
-#grep -E "transformers_v3.0.2\+fastseq_v.* hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm.1k/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 16.4 100
-## todo: bigger bs doesn't increase speed
-#grep -E "transformers_v3.0.2\+fastseq_v.* hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm.1k/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 18.4 100
-
-# Accuracy
-grep "hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val " perf | awk '{print $9}' | awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' | bash range.sh 45 45.1
+grep "hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val " perf \
+	| awk '{print $9}' \
+	| awk -F'|' '{if($1!="NA"){c+=1;s+=$1}}END{print s/c}' \
+	| ./range.sh 45 45.1
 # Speed on V100 16GB 250W
-grep -E "transformers_v3.0.2 hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 2.95 3.05
-grep -E "transformers_v3.0.2\+fastseq_v.* hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 16.5 100
-# todo: bigger bs doesn't increase speed
-grep -E "transformers_v3.0.2\+fastseq_v.* hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 18.3 100
+grep -E "transformers_v3.0.2 hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 3 4
+grep -E "transformers_v3.0.2\+fastseq_v.* hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 64 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 16.5 100
+grep -E "transformers_v3.0.2\+fastseq_v.* hf.sshleifer.distilbart-cnn-12-6.tar.gz cnn_dm/raw val 128 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 18.3 100

--- a/benchmarks/models/hf_mbart.sh
+++ b/benchmarks/models/hf_mbart.sh
@@ -9,10 +9,28 @@
 source utils.sh
 
 # MODEL - mbart
-./benchmark.sh transformers facebook/mbart-large-en-ro wmt_en_ro/raw val 64 --task translation    # each bs takes 5 minutes
-./benchmark.sh transformers+fastseq facebook/mbart-large-en-ro wmt_en_ro/raw val 64 --task translation    # each bs takes 5 minutes
+./benchmark.sh \
+    transformers \
+    facebook/mbart-large-en-ro \
+    wmt_en_ro/raw \
+    val \
+    64 \
+    --task translation
+./benchmark.sh \
+    transformers+fastseq \
+    facebook/mbart-large-en-ro \
+    wmt_en_ro/raw \
+    val \
+    64 \
+    --task translation
 # Accuracy
-grep "facebook/mbart-large-en-ro wmt_en_ro/raw val " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 56.1 56.3
+grep "facebook/mbart-large-en-ro wmt_en_ro/raw val " perf \
+	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
+	| ./range.sh 56.1 56.3
 # Speed on V100 16GB 250W
-grep -E "transformers_v3.0.2 facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 6.0 100
-grep -E "transformers_v3.0.2\+fastseq_v.* facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 9.3 100
+grep -E "transformers_v3.0.2 facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 6.0 100
+grep -E "transformers_v3.0.2\+fastseq_v.* facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 9.3 100

--- a/benchmarks/models/hf_mbart.sh
+++ b/benchmarks/models/hf_mbart.sh
@@ -6,7 +6,7 @@
 #   <task>
 #   <split> # train/val/test (text) or train/valid/test (binary)
 #   <batch-sizes>
-source utils.sh
+source hf.sh
 
 # MODEL - mbart
 ./benchmark.sh \

--- a/benchmarks/models/hf_mbart.sh
+++ b/benchmarks/models/hf_mbart.sh
@@ -26,11 +26,11 @@ source hf.sh
 # Accuracy
 grep "facebook/mbart-large-en-ro wmt_en_ro/raw val " perf \
 	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
-	| ./range.sh 0.561 0.563
+	| ./range.sh 56.1 56.3
 # Speed on V100 16GB 250W
 grep -E "transformers_v3.0.2 facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf \
 	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
 	| ./range.sh 6.0 100
 grep -E "transformers_v3.0.2\+fastseq_v.* facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 9.3 100
+	| ./range.sh 9 100

--- a/benchmarks/models/hf_mbart.sh
+++ b/benchmarks/models/hf_mbart.sh
@@ -26,7 +26,7 @@ source hf.sh
 # Accuracy
 grep "facebook/mbart-large-en-ro wmt_en_ro/raw val " perf \
 	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
-	| ./range.sh 56.1 56.3
+	| ./range.sh 0.561 0.563
 # Speed on V100 16GB 250W
 grep -E "transformers_v3.0.2 facebook/mbart-large-en-ro wmt_en_ro/raw val 64 " perf \
 	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \

--- a/benchmarks/models/hf_t5.sh
+++ b/benchmarks/models/hf_t5.sh
@@ -28,7 +28,7 @@ source hf.sh
 # Accuracy
 grep "t5-base wmt_en_ro/raw val " perf \
 	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
-	| ./range.sh 0.578 0.579
+	| ./range.sh 57.8 57.9
 # Speed on V100 16GB 250W
 grep -E "transformers_v3.0.2 t5-base wmt_en_ro/raw val 64 " perf \
 	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \

--- a/benchmarks/models/hf_t5.sh
+++ b/benchmarks/models/hf_t5.sh
@@ -8,11 +8,33 @@
 #   <batch-sizes>
 source utils.sh
 
-./benchmark.sh transformers t5-base wmt_en_ro/raw val 64 --task translation_en_to_ro --no_repeat_ngram_size 3         # each bs takes 5 minutes
-./benchmark.sh transformers+fastseq t5-base wmt_en_ro/raw val 64/128 --task translation_en_to_ro --no_repeat_ngram_size 3  # each bs takes 5 minutes
+./benchmark.sh \
+    transformers \
+    t5-base \
+    wmt_en_ro/raw \
+    val \
+    64 \
+    --task translation_en_to_ro \
+    --no_repeat_ngram_size 3
+./benchmark.sh \
+    transformers+fastseq \
+    t5-base \
+    wmt_en_ro/raw \
+    val \
+    64/128 \
+    --task translation_en_to_ro \
+    --no_repeat_ngram_size 3
 # Accuracy
-grep "t5-base wmt_en_ro/raw val " perf | awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' | bash range.sh 27.42 27.44
+grep "t5-base wmt_en_ro/raw val " perf \
+	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
+	| ./range.sh 56.91 56.94
 # Speed on V100 16GB 250W
-grep -E "transformers_v3.0.2 t5-base wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 4.6 5.2
-grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 64 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 19.3 100
-grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 128 " perf | awk '{s+=$13}END{print s/NR}' | bash range.sh 23.4 100
+grep -E "transformers_v3.0.2 t5-base wmt_en_ro/raw val 64 " perf \
+	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
+	| ./range.sh 5 100
+grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 64 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 19.3 100
+grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 128 " perf \
+	| awk '{s+=$13}END{print s/NR}' \
+	| ./range.sh 23.8 100

--- a/benchmarks/models/hf_t5.sh
+++ b/benchmarks/models/hf_t5.sh
@@ -14,8 +14,8 @@ source hf.sh
     wmt_en_ro/raw \
     val \
     64 \
-    --task translation_en_to_ro \
-    --no_repeat_ngram_size 3
+    --task translation_en_to_ro 
+#    --no_repeat_ngram_size 3	# baseline don't support this arg now.
 ./benchmark.sh \
     transformers+fastseq \
     t5-base \
@@ -23,18 +23,19 @@ source hf.sh
     val \
     64/128 \
     --task translation_en_to_ro \
-    --no_repeat_ngram_size 3
+    --postprocess_workers 3
+#    --no_repeat_ngram_size 3
 # Accuracy
 grep "t5-base wmt_en_ro/raw val " perf \
 	| awk '{if($8!="NA"){c+=1;s+=$8}}END{print s/c}' \
-	| ./range.sh 56.91 56.94
+	| ./range.sh 0.578 0.579
 # Speed on V100 16GB 250W
 grep -E "transformers_v3.0.2 t5-base wmt_en_ro/raw val 64 " perf \
 	| awk '{s+=$13}END{if(NR==0) print -1; else print s/NR}' \
-	| ./range.sh 5 100
+	| ./range.sh 8 10
 grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 64 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 19.3 100
+	| ./range.sh 19 100
 grep -E "transformers_v3.0.2\+fastseq_v.* t5-base wmt_en_ro/raw val 128 " perf \
 	| awk '{s+=$13}END{print s/NR}' \
-	| ./range.sh 23.8 100
+	| ./range.sh 30 100

--- a/benchmarks/models/hf_t5.sh
+++ b/benchmarks/models/hf_t5.sh
@@ -6,7 +6,7 @@
 #   <task>
 #   <split> # train/val/test (text) or train/valid/test (binary)
 #   <batch-sizes>
-source utils.sh
+source hf.sh
 
 ./benchmark.sh \
     transformers \

--- a/benchmarks/range.sh
+++ b/benchmarks/range.sh
@@ -2,7 +2,7 @@
 unset n
 read n
 numInRange() {
-   awk -v n="$1" -v low="$2" -v high="$3" 'BEGIN {if(n<low||n>high) print "Error"; else print "Success";}'
+   awk -v n="$1" -v low="$2" -v high="$3" 'BEGIN {if(n==-1) print "Ignored"; if(n<low||n>high) print "Error"; else print "Success";}'
 }
 
 #echo "$n $1 $2"

--- a/benchmarks/utils.sh
+++ b/benchmarks/utils.sh
@@ -34,8 +34,10 @@ download_if_not_in_cache() {
             exit -1
         fi
         if [[ "$#" -eq 3 && $local_path == *.tar.gz ]]; then
+	    wd=`pwd`
             cd `dirname $local_path`
             tar xzvf $local_path
+	    cd $wd
         fi
     else
         echo "Reuse $local_path"
@@ -51,6 +53,12 @@ git_clone_if_not_in_cache() {
         if [ $? -ne 0 ]; then
             echo "Failed to clone '$git_url'"
             exit -1
+        fi
+        if [[ "$#" -eq 3 ]]; then
+	    wd=`pwd`
+            cd $local_path
+	    git checkout tags/$3
+	    cd $wd
         fi
     else
         echo "Reuse $local_path"

--- a/examples/bart/README.md
+++ b/examples/bart/README.md
@@ -87,7 +87,7 @@ $ fastseq-generate-for-transformers \
     --task summarization
 ```
 
-To get the baseline transformers' speed number, we can either add option `--without_fastseq_opt` or use [tool](https://github.com/huggingface/transformers/tree/master/examples/seq2seq) provided in Transformers GitHub repository.
+Baseline speed number is obtained by running [Transformers v3.0.2 code](https://github.com/huggingface/transformers/blob/b0892fa0e8df02d683e05e625b3903209bff362d/examples/seq2seq/run_eval.py).
 
 ### Code Example
 Refer to [file](../../tests/optimizer/transformers/test_bart_optimizer.py).

--- a/examples/distilbart/README.md
+++ b/examples/distilbart/README.md
@@ -35,5 +35,5 @@ $ fastseq-generate-for-transformers \
     --task summarization
 ```
 
-To get the baseline transformers' speed number, we can either add option `--without_fastseq_opt` or use [tool](https://github.com/huggingface/transformers/tree/master/examples/seq2seq) provided in Transformers GitHub repository.
+Baseline speed number is obtained by running [Transformers v3.0.2 code](https://github.com/huggingface/transformers/blob/b0892fa0e8df02d683e05e625b3903209bff362d/examples/seq2seq/run_eval.py).
 

--- a/examples/distilbart/README.md
+++ b/examples/distilbart/README.md
@@ -10,8 +10,8 @@ More info can be found [here](https://github.com/huggingface/transformers/blob/m
 
   |      BatchSize      |       64       |       128      |
   |:-------------------:|:--------------:|:--------------:|
-  | transformers-3.0.2  | 4.3 samples/s  |      OOM       |
-  |  above + fastseq    | 16.5 samples/s  | 18.3 samples/s  |
+  | transformers-3.0.2  | 3.4 samples/s  |      OOM       |
+  |  above + fastseq    | 16.8 samples/s  | 18.5 samples/s  |
 
 
 ### Model
@@ -25,9 +25,9 @@ More info can be found [here](https://github.com/huggingface/transformers/blob/m
 ```bash
 $ fastseq-generate-for-transformers \
     sshleifer/distilbart-cnn-12-6 \
-    cnn_dm.1k/val.source \
+    cnn_dm/val.source \
     out.summary \
-    --reference_path cnn_dm.1k/val.target \
+    --reference_path cnn_dm/val.target \
     --device cuda \
     --bs BATCH_SIZE \
     --fp16 \

--- a/examples/prophetnet/README.md
+++ b/examples/prophetnet/README.md
@@ -10,8 +10,8 @@ A pre-trained language model for sequence-to-sequence learning with a novel self
 
   |       BatchSize      |       32      |        64       |      128       |
   |:--------------------:|:-------------:|:---------------:|:--------------:|
-  |      prophetnet      | 2.8 samples/s |  3.2 samples/s  |      OOM       |
-  |   above + fastseq    | 6.0 samples/s |  8.8 samples/s  | 11.3 samples/s |
+  |      prophetnet      | 2.4 samples/s |  2.8 samples/s  |      OOM       |
+  |   above + fastseq    | 6.0 samples/s |  7.6 samples/s  | 10.7 samples/s |
 
 
 ### Model
@@ -24,7 +24,7 @@ ProphetNet-large-160GB (fine-tuned on CNN/Daily Mail with 9 epochs) [link](https
 
 ```bash
 $ fastseq-generate-for-fairseq \
-      cnn_dm_bert.1k/len-512.bin \
+      cnn_dm_bert/len-512.bin \
       --path prophetnet/model.pt \
       --fp16 \
       --task translation_prophetnet \

--- a/examples/t5/README.md
+++ b/examples/t5/README.md
@@ -9,8 +9,8 @@ The T5 model was presented in [Exploring the Limits of Transfer Learning with a 
 
   |       BatchSize      |        64       |      128       |
   |:--------------------:|:---------------:|:--------------:|
-  |   ransformers_v3.0.2 |  5.0 samples/s  |      OOM       |
-  |   above + fastseq    |  19.3 samples/s  | 23.4 samples/s  |
+  |   ransformers_v3.0.2 |  5.7 samples/s  |      OOM       |
+  |   above + fastseq    |  19.3 samples/s  | 24.0 samples/s  |
 
 
 ### Model

--- a/examples/t5/README.md
+++ b/examples/t5/README.md
@@ -9,8 +9,8 @@ The T5 model was presented in [Exploring the Limits of Transfer Learning with a 
 
   |       BatchSize      |        64       |      128       |
   |:--------------------:|:---------------:|:--------------:|
-  |   ransformers_v3.0.2 |  5.7 samples/s  |      OOM       |
-  |   above + fastseq    |  19.3 samples/s  | 24.0 samples/s  |
+  |   ransformers_v3.0.2 |  8.7 samples/s  |      OOM       |
+  |   above + fastseq    |  19.5 samples/s | 31.3 samples/s  |
 
 
 ### Model
@@ -39,9 +39,9 @@ $ fastseq-generate-for-transformers \
     --fp16 \
     --score_path out.score \
     --task translation_en_to_ro \
-    --no_repeat_ngram_size 3
+    --postprocess_workers 3
 ```
-To get the baseline transformers' speed number, we can either add option `--without_fastseq_opt` or use [tool](https://github.com/huggingface/transformers/tree/master/examples/seq2seq) provided in Transformers GitHub repository.
+Baseline speed number is obtained by running [Transformers v3.0.2 code](https://github.com/huggingface/transformers/blob/b0892fa0e8df02d683e05e625b3903209bff362d/examples/seq2seq/run_eval.py).
 
 ### Code Example
 Refer to [file](../../tests/optimizer/transformers/test_t5_optimizer.py).

--- a/fastseq_cli/transformers_utils.py
+++ b/fastseq_cli/transformers_utils.py
@@ -301,7 +301,7 @@ def calculate_rouge(output_lns: List[str],
         aggregator.add_scores(scores)
 
     result = aggregator.aggregate()
-    return {k: v.mid.fmeasure * 100 for k, v in result.items()}
+    return {k: v.mid.fmeasure for k, v in result.items()}
 
 
 def freeze_params(model: nn.Module):


### PR DESCRIPTION
Changes:
1. Use cnn dm full validation data for prophetnet. 1k data is too small now.
2. Use real transformer code as baseline. It is more accurate.
3. Fix some issues.