### PR TITLE
Early exit for ngram blocking.

### DIFF
--- a/fastseq/clib/cuda/ngram_repeat_block_cuda_kernel.cu
+++ b/fastseq/clib/cuda/ngram_repeat_block_cuda_kernel.cu
@@ -41,6 +41,7 @@ __global__ void banRepeatedTokens(long* __restrict__ tokens,
   for (int k = 0; k < no_repeat_ngram_size - 1; k++) {
     if (tokens_shm[col + k] != tokens_shm[check_start_pos + k]) {
       is_banned = false;
+      break;
     }
   }
   if (is_banned == true) {


### PR DESCRIPTION
When ngram prefix doesn't match, early stop.